### PR TITLE
hardcode mailform config to prevent config disclosure

### DIFF
--- a/bat/rd-mailform.config.json
+++ b/bat/rd-mailform.config.json
@@ -1,8 +1,0 @@
-{
-  "useSmtp": false,
-  "host": "stmp.gmail.com",              
-  "port": 465,													 
-  "username": "demo@gmail.com",					 
-  "password": "demopassword",						 
-  "recipientEmail":  "demo@gmail.com"		 
-}

--- a/bat/rd-mailform.php
+++ b/bat/rd-mailform.php
@@ -1,7 +1,13 @@
 <?php
 
-$formConfigFile = file_get_contents("rd-mailform.config.json");
-$formConfig = json_decode($formConfigFile, true);
+$formConfig = array(
+  "useSmtp" => false,
+  "host" => "stmp.gmail.com",
+  "port" => 465,
+  "username" => "demo@gmail.com",
+  "password" => "demopassword",
+  "recipientEmail" =>  "demo@gmail.com"
+);
 
 date_default_timezone_set('Etc/UTC');
 


### PR DESCRIPTION
Hello,
While auditing a website of some customer found the following risk: 
If the developer didn't secure this file ie: move it to a non-public location, an attacker could disclose the email config by visiting **http://$HOST/bat/rd-mailform.config.json**.
I hard-coded the config in rd-mailform.php 